### PR TITLE
cclean-air-api : ajout du controlleur de vérification de la connexion…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,19 @@
 
 ### Requêtes utiles à différents modules
 
+#### Requête pour récupérer la commune présente en base la plus proche 
+
+[POST] /communes/plus_proche
+[longitude, latitude]
+
+```JSON
+[-1.553621, 47.218371]
+```
+
+Réponse en cas de succès :
+
+Code `200`
+
 #### Requête pour récupérer toutes les communes de Loire-Atlantique
 
 [GET] /communes
@@ -103,18 +116,20 @@ Réponse en cas d'échec :
 
 Code `401`
 
-#### Requête pour récupérer la commune présente en base la plus proche 
+#### Requête pour tester l'authentification
 
-[POST] /communes/plus_proche
-[longitude, latitude]
-
-```JSON
-[-1.553621, 47.218371]
-```
-
-Réponse en cas de succès :
+[GET] /connexion
+``
+Réponse :
 
 Code `200`
+
+Réponse avec le filtre activé, en cas de cookie non présent ou invalide :
+
+Code `403`
+
+Commentaire : cette requête s'appui`e sur le fait que le filtre va renvoyé un
+ code 403 si jamais l'utilisateur n'est pas déjà authentifié.
 
 #### Requête pour modifier son compte
 
@@ -154,7 +169,6 @@ Réponse en cas de succès :
 
 Code `200`
 
-```
 
 #### Requête pour récupérer les données pour affichage sur la carte
 
@@ -193,8 +207,6 @@ Code `200`
 Réponse en cas d'échec :
 
 Code `404`
-
-```
 
 #### Cas d’utilisation “Visualiser données pollution” 
 

--- a/src/main/java/dev/config/WebSecurityConfig.java
+++ b/src/main/java/dev/config/WebSecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -57,7 +58,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
 		http.cors();
 
-		http.csrf().disable().authorizeRequests().antMatchers("/connexion").permitAll().antMatchers("/comptes")
+		http.csrf().disable().authorizeRequests()
+				.antMatchers(HttpMethod.POST, "/connexion").permitAll()
+				.antMatchers(HttpMethod.GET, "/connexion").authenticated()
+				.antMatchers(HttpMethod.GET, "/communes").permitAll()
+				.antMatchers("/comptes")
 				.permitAll().antMatchers("/h2-console/**").permitAll().antMatchers("/admin/**")
 				.hasAuthority("ADMINISTRATEUR").anyRequest().authenticated().and().headers().frameOptions().disable()
 				.and().addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class).logout()

--- a/src/main/java/dev/controllers/ConnexionController.java
+++ b/src/main/java/dev/controllers/ConnexionController.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -121,5 +122,16 @@ public class ConnexionController {
 					}
 					return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();					
 							});
+	}
+
+	/**
+	 * Contrôleur gérant la requête GET permettant de valider le fait que
+	 * l'utilisateur est déjà authentifié (cookie présent).
+	 *
+	 * @return : ResponseEntity<Void> Réponse au body vide avec statut 200.
+	 */
+	@GetMapping("/connexion")
+	public ResponseEntity<Void> reqVerificationEstConnecte() {
+		return ResponseEntity.ok().build();
 	}
 }


### PR DESCRIPTION
… et modif pour accès à la liste des communes sans authentification

/communes accessible sans être authentifié

[GET] /connexion permet de dire si utilisateur déjà authentifié (200 si OK, 403 sinon)